### PR TITLE
Float warnings

### DIFF
--- a/external_packages/qpOASES-3.0beta/include/qpOASES/PrivateUtils.hpp
+++ b/external_packages/qpOASES-3.0beta/include/qpOASES/PrivateUtils.hpp
@@ -1,0 +1,54 @@
+/*
+ *	This file is part of qpOASES.
+ *
+ *	qpOASES -- An Implementation of the Online Active Set Strategy.
+ *	Copyright (C) 2007-2011 by Hans Joachim Ferreau, Andreas Potschka,
+ *	Christian Kirches et al. All rights reserved.
+ *
+ *	qpOASES is free software; you can redistribute it and/or
+ *	modify it under the terms of the GNU Lesser General Public
+ *	License as published by the Free Software Foundation; either
+ *	version 2.1 of the License, or (at your option) any later version.
+ *
+ *	qpOASES is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *	See the GNU Lesser General Public License for more details.
+ *
+ *	You should have received a copy of the GNU Lesser General Public
+ *	License along with qpOASES; if not, write to the Free Software
+ *	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+/**
+ *	\file include/qpOASES/Bounds.hpp
+ * 
+ *  Private utility functions for use in qpOASES 
+ *
+ * The only private utilities that currently exist are exact floating
+ * point comparisons for 1, 0 and -1 which are used to centralize pragma 
+ * workings for gcc's Wfloat-equal.
+ */
+
+#ifndef QPOASES_PRIVATEUTILS_HPP
+#define QPOASES_PRIVATEUTILS_HPP
+
+#include "Types.hpp"
+
+BEGIN_NAMESPACE_QPOASES
+
+/** Return true if and only if argument is exactly 1 */
+inline bool isExactlyOne(real_t a);
+
+/** Return true if and only if argument is exactly 0 */
+inline bool isExactlyZero(real_t a);
+
+/** Return true if and only if argument is exactly -1 */
+inline bool isExactlyMinusOne(real_t a);
+
+END_NAMESPACE_QPOASES
+
+#include "PrivateUtils.ipp"
+
+#endif

--- a/external_packages/qpOASES-3.0beta/include/qpOASES/PrivateUtils.ipp
+++ b/external_packages/qpOASES-3.0beta/include/qpOASES/PrivateUtils.ipp
@@ -1,0 +1,52 @@
+/*
+ *	This file is part of qpOASES.
+ *
+ *	qpOASES -- An Implementation of the Online Active Set Strategy.
+ *	Copyright (C) 2007-2011 by Hans Joachim Ferreau, Andreas Potschka,
+ *	Christian Kirches et al. All rights reserved.
+ *
+ *	qpOASES is free software; you can redistribute it and/or
+ *	modify it under the terms of the GNU Lesser General Public
+ *	License as published by the Free Software Foundation; either
+ *	version 2.1 of the License, or (at your option) any later version.
+ *
+ *	qpOASES is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *	See the GNU Lesser General Public License for more details.
+ *
+ *	You should have received a copy of the GNU Lesser General Public
+ *	License along with qpOASES; if not, write to the Free Software
+ *	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+/**
+* \file include/qpOASES/PrivateUtils.ipp
+*
+* Inline implementation of functions declared in PrivateUtils.hpp
+*/
+
+BEGIN_NAMESPACE_QPOASES
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+
+inline bool isExactlyOne(real_t a)
+{
+  return a==1.0;
+}
+
+inline bool isExactlyZero(real_t a)
+{
+  return a==0.0;
+}
+
+inline bool isExactlyMinusOne(real_t a)
+{
+  return a==-1.0;
+}
+
+#pragma GCC diagnostic pop
+
+END_NAMESPACE_QPOASES

--- a/external_packages/qpOASES-3.0beta/src/BLASReplacement.cpp
+++ b/external_packages/qpOASES-3.0beta/src/BLASReplacement.cpp
@@ -31,7 +31,9 @@
  *	BLAS Level 3 replacement routines.
  */
 
+#include <qpOASES/PrivateUtils.hpp>
 
+USING_NAMESPACE_QPOASES
 
 extern "C" void dgemm_ ( const char *TRANSA, const char *TRANSB,
 		const unsigned long *M, const unsigned long *N, const unsigned long *K,
@@ -40,26 +42,26 @@ extern "C" void dgemm_ ( const char *TRANSA, const char *TRANSB,
 {
 	unsigned int i, j, k;
 
-	if (*BETA == 0.0)
+	if (isExactlyZero(*BETA))
 		for (k = 0; k < *N; k++)
 			for (j = 0; j < *M; j++)
 				C[j+(*LDC)*k] = 0.0;
-	else if (*BETA == -1.0)
+	else if (isExactlyMinusOne(*BETA))
 		for (k = 0; k < *N; k++)
 			for (j = 0; j < *M; j++)
 				C[j+(*LDC)*k] = -C[j+(*LDC)*k];
-	else if (*BETA != 1.0)
+	else if (!isExactlyOne(*BETA))
 		for (k = 0; k < *N; k++)
 			for (j = 0; j < *M; j++)
 				C[j+(*LDC)*k] *= *BETA;
 
 	if (TRANSA[0] == 'N')
-		if (*ALPHA == 1.0)
+		if (isExactlyOne(*ALPHA))
 			for (k = 0; k < *N; k++)
 				for (j = 0; j < *M; j++)
 					for (i = 0; i < *K; i++)
 						C[j+(*LDC)*k] += A[j+(*LDA)*i] * B[i+(*LDB)*k];
-		else if (*ALPHA == -1.0)
+		else if (isExactlyMinusOne(*ALPHA))
 			for (k = 0; k < *N; k++)
 				for (j = 0; j < *M; j++)
 					for (i = 0; i < *K; i++)
@@ -70,12 +72,12 @@ extern "C" void dgemm_ ( const char *TRANSA, const char *TRANSB,
 					for (i = 0; i < *K; i++)
 						C[j+(*LDC)*k] += *ALPHA * A[j+(*LDA)*i] * B[i+(*LDB)*k];
 	else
-		if (*ALPHA == 1.0)
+		if (isExactlyOne(*ALPHA))
 			for (k = 0; k < *N; k++)
 				for (j = 0; j < *M; j++)
 					for (i = 0; i < *K; i++)
 						C[j+(*LDC)*k] += A[i+(*LDA)*j] * B[i+(*LDB)*k];
-		else if (*ALPHA == -1.0)
+		else if (isExactlyMinusOne(*ALPHA))
 			for (k = 0; k < *N; k++)
 				for (j = 0; j < *M; j++)
 					for (i = 0; i < *K; i++)
@@ -94,26 +96,26 @@ extern "C" void sgemm_ ( const char *TRANSA, const char *TRANSB,
 {
 	unsigned int i, j, k;
 
-	if (*BETA == 0.0)
+	if (isExactlyZero(*BETA))
 		for (k = 0; k < *N; k++)
 			for (j = 0; j < *M; j++)
 				C[j+(*LDC)*k] = 0.0;
-	else if (*BETA == -1.0)
+	else if (isExactlyMinusOne(*BETA))
 		for (k = 0; k < *N; k++)
 			for (j = 0; j < *M; j++)
 				C[j+(*LDC)*k] = -C[j+(*LDC)*k];
-	else if (*BETA != 1.0)
+	else if (!isExactlyOne(*BETA))
 		for (k = 0; k < *N; k++)
 			for (j = 0; j < *M; j++)
 				C[j+(*LDC)*k] *= *BETA;
 
 	if (TRANSA[0] == 'N')
-		if (*ALPHA == 1.0)
+		if (isExactlyOne(*ALPHA))
 			for (k = 0; k < *N; k++)
 				for (j = 0; j < *M; j++)
 					for (i = 0; i < *K; i++)
 						C[j+(*LDC)*k] += A[j+(*LDA)*i] * B[i+(*LDB)*k];
-		else if (*ALPHA == -1.0)
+		else if (isExactlyMinusOne(*ALPHA))
 			for (k = 0; k < *N; k++)
 				for (j = 0; j < *M; j++)
 					for (i = 0; i < *K; i++)
@@ -124,12 +126,12 @@ extern "C" void sgemm_ ( const char *TRANSA, const char *TRANSB,
 					for (i = 0; i < *K; i++)
 						C[j+(*LDC)*k] += *ALPHA * A[j+(*LDA)*i] * B[i+(*LDB)*k];
 	else
-		if (*ALPHA == 1.0)
+		if (isExactlyOne(*ALPHA))
 			for (k = 0; k < *N; k++)
 				for (j = 0; j < *M; j++)
 					for (i = 0; i < *K; i++)
 						C[j+(*LDC)*k] += A[i+(*LDA)*j] * B[i+(*LDB)*k];
-		else if (*ALPHA == -1.0)
+		else if (isExactlyMinusOne(*ALPHA))
 			for (k = 0; k < *N; k++)
 				for (j = 0; j < *M; j++)
 					for (i = 0; i < *K; i++)

--- a/external_packages/qpOASES-3.0beta/src/Matrices.cpp
+++ b/external_packages/qpOASES-3.0beta/src/Matrices.cpp
@@ -34,6 +34,7 @@
 
 #include <qpOASES.hpp>
 
+#include <qpOASES/PrivateUtils.hpp>
 
 BEGIN_NAMESPACE_QPOASES
 
@@ -43,29 +44,9 @@ const char * const TRANS = "TRANS";
 /** String for calling LAPACK/BLAS routines without transposing the matrix. */
 const char * const NOTRANS = "NOTRANS";
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wfloat-equal"
-static inline bool isExactlyOne(real_t a)
-{
-  return a==1.0;
-}
-
-static inline bool isExactlyZero(real_t a)
-{
-  return a==0.0;
-}
-
-static inline bool isExactlyMinusOne(real_t a)
-{
-  return a==-1.0;
-}
-#pragma GCC diagnostic pop
-
 /*****************************************************************************
  *  P U B L I C                                                              *
  *****************************************************************************/
-
-
 
 DenseMatrix::~DenseMatrix()
 {


### PR DESCRIPTION
The second of three branches aimed at reducing warnings when compiling with gcc.

This is aimed the at -Wfloat-equals warnings.  The only comparisons are to -1, 0, and 1; I have pulled these out into three inline functions (isExactlyMinusOne(), etc.) which are inside a pragma block disabling the warning.  The functions are in hpp/ipp files, modelled on existing ACADO code.

One non-pragma solution is something like abs(1-a) < DBL_EPSILON (or equivalent using std::numeric_limits), but that seems silly.

Alternatively -Wfloat-equal could be disabled specifically for these files.

Incidentally, I first thought branching on -1, 1, 0 etc. was a pointless micro-optimization, but some benchmarking with big enough datasets showed something like a 20% speedup.
