### PR TITLE
Bugfix: handle no-element case when printing expression.

### DIFF
--- a/src/symbolic_expression/expression.cpp
+++ b/src/symbolic_expression/expression.cpp
@@ -357,9 +357,12 @@ Stream Expression::print( Stream &stream ) const{
 
     uint run1;
     stream << "[ ";
-    for( run1 = 0; run1 < dim-1; run1++ )
-        stream << *element[run1] << " , ";
-    stream << *element[dim-1];
+    if(dim)
+      {
+        for( run1 = 0; run1 < dim-1; run1++ )
+          stream << *element[run1] << " , ";
+        stream << *element[dim-1];
+      }
     stream << "]";
 
     return stream;


### PR DESCRIPTION
Without this fix, Expression::print() causes a segfault when dim is 0.
