### PR TITLE
Isequal uses fabs 2

### DIFF
--- a/src/utils/acado_utils.cpp
+++ b/src/utils/acado_utils.cpp
@@ -242,7 +242,7 @@ BooleanType acadoIsEqual( const char* str1, const char* str2 )
 BooleanType acadoIsEqual( double x, double y, double TOL ){
 
   double maxabs= acadoMax(fabs(x),fabs(y));
-	if(maxabs  > 1)
+	if(maxabs > 1)
 	{
 		// use relative error
 		if ( fabs( x-y )/maxabs >= 10.0*TOL ) return BT_FALSE;


### PR DESCRIPTION
Code previously used maximum of signed arguments to decide whether to
use relative or absolute tolerance check.  If this function is to also
be used to compare negative numbers of large magnitude, the absolute
value of its arguments should be used.

Before the fix, this code

```
#include "acado_toolkit.hpp"

int main()
{
  std::cout << ACADO::acadoIsEqual(10000,10000+1e-7) << "\n";
  std::cout << ACADO::acadoIsEqual(10000,10000-1e-7) << "\n";
  std::cout << ACADO::acadoIsEqual(-10000,-10000+1e-7) << "\n";
  std::cout << ACADO::acadoIsEqual(-10000,-10000-1e-7) << "\n";
}
```

produces this:

```
1
1
0
0
```

and after it produces this:

```
1
1
1
1
```
