### PR TITLE
Declare mexInput variables in FB to avoid erros due to their use before ...

### DIFF
--- a/interfaces/matlab/acado/packages/+acado/@MexInput/getInstructions.m
+++ b/interfaces/matlab/acado/packages/+acado/@MexInput/getInstructions.m
@@ -28,7 +28,7 @@ function getInstructions(obj, cppobj, get)
 % 
 
 
-if (get == 'B')
+if (get == 'FB')
 
     fprintf(cppobj.fileMEX,sprintf('    double *%s_temp = NULL; \n', obj.name));
     fprintf(cppobj.fileMEX,sprintf('    if( !mxIsDouble(prhs[%d]) || mxIsComplex(prhs[%d]) || !(mxGetM(prhs[%d])==1 && mxGetN(prhs[%d])==1) ) { \n', obj.counter, obj.counter, obj.counter, obj.counter));


### PR DESCRIPTION
...declaration
