### PR TITLE
Declare mexInput variables in FB to avoid erros due to their use before ...

### DIFF
--- a/interfaces/matlab/acado/packages/+acado/@MexInputMatrix/getInstructions.m
+++ b/interfaces/matlab/acado/packages/+acado/@MexInputMatrix/getInstructions.m
@@ -29,7 +29,7 @@ function getInstructions(obj, cppobj, get)
 
 
 
-if (get == 'B')
+if (get == 'FB')
     
 
     fprintf(cppobj.fileMEX,sprintf('    double *%s_temp = NULL; \n', obj.name));


### PR DESCRIPTION
...declaration
