### PR TITLE
Declare mexInput variables in FB to avoid erros due to their use before ...

### DIFF
--- a/interfaces/matlab/acado/packages/+acado/@MexInputVector/getInstructions.m
+++ b/interfaces/matlab/acado/packages/+acado/@MexInputVector/getInstructions.m
@@ -28,7 +28,7 @@ function getInstructions(obj, cppobj, get)
 % 
 
 
-if (get == 'B')
+if (get == 'FB')
     
     fprintf(cppobj.fileMEX,sprintf('    int %s_count = 0;\n', obj.name));
     fprintf(cppobj.fileMEX,sprintf('    if (mxGetM(prhs[%d]) == 1 && mxGetN(prhs[%d]) >= 1) \n', obj.counter, obj.counter));


### PR DESCRIPTION
...declaration
