### PR TITLE
#include <unistd.h> should not be included on WIN32

### DIFF
--- a/external_packages/src/acado_gnuplot/gnuplot_window.cpp
+++ b/external_packages/src/acado_gnuplot/gnuplot_window.cpp
@@ -37,11 +37,12 @@
 #include <windows.h>
 
 #define round( value ) floor( value + 0.5 )
+#else
+#include <unistd.h>
 #endif
 
 #include <cstdlib>
 #include <string>
-#include <unistd.h>
 
 BEGIN_NAMESPACE_ACADO
 


### PR DESCRIPTION
WIN32 does not have "unitstd.h", this gives an compilation error. Not including it in WIN32 does not give any error.
