### PR TITLE
Some performance improvements for when OCP is called in a loop

### DIFF
--- a/acado/conic_solver/condensing_based_cp_solver.cpp
+++ b/acado/conic_solver/condensing_based_cp_solver.cpp
@@ -419,20 +419,23 @@ returnValue CondensingBasedCPsolver::solveCPsubproblem( )
     if( levenbergMarquard > EPS )
     	denseCP.H += eye<double>( denseCP.H.rows() ) * levenbergMarquard;
 
-	// Check condition number of the condensed Hessian.
-    double denseHConditionNumber = denseCP.H.getConditionNumber();
-    if (denseHConditionNumber > 1.0e16)
+    if ( LVL_WARNING < Logger::instance().getLogLevel() )
     {
-    	LOG( LVL_WARNING )
-    			<< "Condition number of the condensed Hessian is quite high: log_10(kappa( H )) = "
-    			<< log10( denseHConditionNumber ) << endl;
-    	ACADOWARNING( RET_ILLFORMED_HESSIAN_MATRIX );
-    }
-    // Check for max and min entry in the condensed Hessian:
-    if (denseCP.H.getMin() < -1.0e16 || denseCP.H.getMax() > 1.0e16)
-    {
-    	LOG( LVL_WARNING ) << "Ill formed condensed Hessian: min(.) < -1e16 or max(.) > 1e16" << endl;
-    	ACADOWARNING( RET_ILLFORMED_HESSIAN_MATRIX );
+      // Check condition number of the condensed Hessian.
+      double denseHConditionNumber = denseCP.H.getConditionNumber();
+      if (denseHConditionNumber > 1.0e16)
+      {
+        LOG( LVL_WARNING )
+            << "Condition number of the condensed Hessian is quite high: log_10(kappa( H )) = "
+            << log10( denseHConditionNumber ) << endl;
+        ACADOWARNING( RET_ILLFORMED_HESSIAN_MATRIX );
+      }
+      // Check for max and min entry in the condensed Hessian:
+      if (denseCP.H.getMin() < -1.0e16 || denseCP.H.getMax() > 1.0e16)
+      {
+        LOG( LVL_WARNING ) << "Ill formed condensed Hessian: min(.) < -1e16 or max(.) > 1e16" << endl;
+        ACADOWARNING( RET_ILLFORMED_HESSIAN_MATRIX );
+      }
     }
 
     // SOLVE QP ALLOWING THE GIVEN NUMBER OF ITERATIONS:

--- a/acado/nlp_solver/scp_method.cpp
+++ b/acado/nlp_solver/scp_method.cpp
@@ -247,8 +247,8 @@ returnValue SCPmethod::init(	VariablesGrid* x_init ,
 	// freeze condensing in case OCP is QP -- isCP is a bit misleading...
 	if ( ( isCP == BT_TRUE ) && ( eval->hasLSQobjective( ) == BT_TRUE ) )
 	{
- 		bandedCPsolver->freezeCondensing( );
- 		eval->freezeSensitivities( );
+ 		// bandedCPsolver->freezeCondensing( );
+ 		// eval->freezeSensitivities( );
 	}
 
 	status = BS_READY;

--- a/acado/nlp_solver/scp_method.cpp
+++ b/acado/nlp_solver/scp_method.cpp
@@ -247,8 +247,8 @@ returnValue SCPmethod::init(	VariablesGrid* x_init ,
 	// freeze condensing in case OCP is QP -- isCP is a bit misleading...
 	if ( ( isCP == BT_TRUE ) && ( eval->hasLSQobjective( ) == BT_TRUE ) )
 	{
-// 		bandedCPsolver->freezeCondensing( );
-// 		eval->freezeSensitivities( );
+ 		bandedCPsolver->freezeCondensing( );
+ 		eval->freezeSensitivities( );
 	}
 
 	status = BS_READY;


### PR DESCRIPTION
These are two minor changes that I believe improve the code execution speed in the case where OCP is recursively called in a loop. One is very non-intrusive (it changes when an SVD computation is needed to be performed). As for the other (freeze condensing) I found that it improves speed while not affecting the results in any noticeable form. That said, I can undo this second change if you feel that it may cause instability.