### PR TITLE
If PRINTLEVEL = NONE, do not display RET_MAX_NUMBER_OF_STEPS_EXCEEDED.

### DIFF
--- a/acado/optimization_algorithm/optimization_algorithm.cpp
+++ b/acado/optimization_algorithm/optimization_algorithm.cpp
@@ -112,9 +112,18 @@ returnValue OptimizationAlgorithm::solve( ){
         returnvalue != CONVERGENCE_ACHIEVED )
 	{
 		if ( returnvalue == RET_MAX_NUMBER_OF_STEPS_EXCEEDED)
-			return ACADOERROR( RET_MAX_NUMBER_OF_STEPS_EXCEEDED );
+    {
+      int PrintLevel; 
+      get( PRINTLEVEL, PrintLevel ); 
+      if (PrintLevel != NONE)
+      {
+  			return ACADOERROR( RET_MAX_NUMBER_OF_STEPS_EXCEEDED );
+      }
+    }
 		else
+    {
 			return ACADOERROR( RET_OPTALG_SOLVE_FAILED );
+    }
 	}
     return SUCCESSFUL_RETURN;
 }


### PR DESCRIPTION
This is a minor change so that if PRINTLEVEL is set to NONE by the user, the "maximum-number-of-iterations-exceeded" message does not display. 

This is helpful for when the solver is called online in a loop. A non-converged solution may still be a good enough solution for real-time control. There's no need to display an error when the user has chosen to 1) manually set MAX_NUM_ITERATIONS, and 2) disable prints via setting PRINTLEVEL to NONE.