### PR TITLE
Commented out a message that gets displayed even when PRINTLEVEL is set to NONE

### DIFF
--- a/acado/objective/lsq_term.ipp
+++ b/acado/objective/lsq_term.ipp
@@ -52,7 +52,7 @@ returnValue LSQTerm::setGrid( const Grid &grid_ ){
              S_temp->init( tmp,grid );
          }
          else{
-              printf("%d  %d  \n", grid.getNumPoints(), S_temp->getNumPoints() );
+              //printf("%d  %d  \n", grid.getNumPoints(), S_temp->getNumPoints() );
               ASSERT( grid.getNumPoints() == S_temp->getNumPoints() );
          }
     }


### PR DESCRIPTION
The same line was already commented out in acado/simulation_environment/simulation_environment.cpp.

If you call the method in a loop, you end up with a stream of nonsense numbers on the screen.
