### PR TITLE
Escape gnuplot path

### DIFF
--- a/acado/bindings/acado_gnuplot/gnuplot_window.cpp
+++ b/acado/bindings/acado_gnuplot/gnuplot_window.cpp
@@ -576,7 +576,7 @@ returnValue GnuplotWindow::sendDataToGnuplot( )
 		gnuPipe = 0;
 
 #if defined(GNUPLOT_EXECUTABLE) && defined(WIN32)
-		string tmp = string( GNUPLOT_EXECUTABLE ) + string(" -p acado2gnuplot_tmp.dat");
+		string tmp = string("\"") + string( GNUPLOT_EXECUTABLE ) + string("\" -p acado2gnuplot_tmp.dat");
 
 		if ( system( tmp.c_str() ) )
 			return RET_PLOTTING_FAILED;


### PR DESCRIPTION
I get an error message when gnuplot is located in a path with space (e.g., "C:\Program Files\gnuplot"). This fixes this bug.